### PR TITLE
adds type annotation for accepting TextIOBase in alhambra.mixes.load_reference function

### DIFF
--- a/src/alhambra/mixes.py
+++ b/src/alhambra/mixes.py
@@ -3,6 +3,8 @@ A module for handling mixes.
 """
 
 from __future__ import annotations
+
+import io
 from abc import ABC, abstractmethod
 from decimal import Decimal
 
@@ -1957,5 +1959,5 @@ class Reference:
         return cls().update(files, round=round)
 
 
-def load_reference(filename_or_file: str) -> Reference:
+def load_reference(filename_or_file: str | io.TextIOBase) -> Reference:
     return Reference.from_csv(filename_or_file)


### PR DESCRIPTION
The function alhambra.mixes.load_reference works if the parameter is of type `io.TextIOBase` (for example, an instance of `io.StringIO`, used for creating file-like objects whose contents are a string in memory).

This PR adds a type annotation to the parameter of `alhambra.mixes.load_reference` so that mypy does not report an error.