### PR TITLE
Change MixLine to have plate, wells, names, and do formatting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,3 +3,4 @@
 - Volume and concentration settings can now be changed, not just initialized, as strings.
 - Reference data for mixes is now its own class, `Reference`, and rounds to 1e-6 nM.
 - Mixes now use Decimal instead of floats throughout for units, solving floating point errors.
+- Formatting for mix table entries now takes place in `MixLine`.

--- a/src/alhambra/mixes.py
+++ b/src/alhambra/mixes.py
@@ -915,7 +915,7 @@ class FixedVolume(AbstractAction):
                 dest_conc=self.dest_concentration(mix_vol),
                 total_tx_vol=self.tx_volume(mix_vol),
                 plate=self.component.location[0],
-                wells=([well] if well else [])
+                wells=([well] if well else []),
             )
         ]
 
@@ -1084,7 +1084,9 @@ class MultiFixedVolume(AbstractAction):
     ) -> Sequence[Quantity[Decimal]]:
         return [
             x * y
-            for x,y in zip(self.source_concentrations, _ratio(self.each_volumes(mix_vol), mix_vol))
+            for x, y in zip(
+                self.source_concentrations, _ratio(self.each_volumes(mix_vol), mix_vol)
+            )
         ]
 
     def each_volumes(
@@ -1126,7 +1128,7 @@ class MultiFixedVolume(AbstractAction):
                     dc,
                     ev,
                     plate=comp.plate,
-                    wells=comp._well_list
+                    wells=comp._well_list,
                 )
                 for dc, ev, comp in zip(
                     self.dest_concentrations(mix_vol),
@@ -1182,7 +1184,6 @@ class MultiFixedVolume(AbstractAction):
             by=["plate", "ea_vols", "well"], ascending=[True, False, True]
         )
 
-
         names: list[list[str]] = []
         source_concs: list[Quantity[Decimal]] = []
         dest_concs: list[Quantity[Decimal]] = []
@@ -1192,8 +1193,10 @@ class MultiFixedVolume(AbstractAction):
         plates: list[str] = []
         wells_list: list[list[WellPos]] = []
 
-        for plate, plate_comps in locdf.groupby("plate"): # type: str, pd.DataFrame
-            for vol, plate_vol_comps in plate_comps.groupby("ea_vols"): # type: Quantity[Decimal], pd.DataFrame
+        for plate, plate_comps in locdf.groupby("plate"):  # type: str, pd.DataFrame
+            for vol, plate_vol_comps in plate_comps.groupby(
+                "ea_vols"
+            ):  # type: Quantity[Decimal], pd.DataFrame
                 if pd.isna(plate_vol_comps["well"].iloc[0]):
                     if not pd.isna(plate_vol_comps["well"]).all():
                         raise ValueError
@@ -1241,7 +1244,7 @@ class MultiFixedVolume(AbstractAction):
                 each_tx_vol=each_tx_vol,
                 total_tx_vol=total_tx_vol,
                 plate=plate,
-                wells=wells
+                wells=wells,
             )
             for name, source_conc, dest_conc, number, each_tx_vol, total_tx_vol, plate, wells in zip(
                 names,
@@ -1392,7 +1395,7 @@ class MultiFixedConcentration(AbstractAction):
                     dc,
                     ev,
                     plate=comp.plate,
-                    wells=comp._well_list
+                    wells=comp._well_list,
                 )
                 for dc, ev, comp in zip(
                     self.dest_concentrations(mix_vol),
@@ -1442,7 +1445,6 @@ class MultiFixedConcentration(AbstractAction):
             by=["plate", "ea_vols", "well"], ascending=[True, False, True]
         )
 
-
         names: list[list[str]] = []
         source_concs: list[Quantity[Decimal]] = []
         dest_concs: list[Quantity[Decimal]] = []
@@ -1452,8 +1454,10 @@ class MultiFixedConcentration(AbstractAction):
         plates: list[str] = []
         wells_list: list[list[WellPos]] = []
 
-        for plate, plate_comps in locdf.groupby("plate"): # type: str, pd.DataFrame
-            for vol, plate_vol_comps in plate_comps.groupby("ea_vols"): # type: Quantity[Decimal], pd.DataFrame
+        for plate, plate_comps in locdf.groupby("plate"):  # type: str, pd.DataFrame
+            for vol, plate_vol_comps in plate_comps.groupby(
+                "ea_vols"
+            ):  # type: Quantity[Decimal], pd.DataFrame
                 if pd.isna(plate_vol_comps["well"].iloc[0]):
                     if not pd.isna(plate_vol_comps["well"]).all():
                         raise ValueError
@@ -1466,7 +1470,7 @@ class MultiFixedConcentration(AbstractAction):
                     plates.append(plate)
                     wells_list.append([])
                     continue
-                
+
                 byrow = mixgaps(
                     sorted(list(plate_vol_comps["well"]), key=WellPos.key_byrow),
                     by="row",
@@ -1484,14 +1488,14 @@ class MultiFixedConcentration(AbstractAction):
 
                 plate_vol_comps.sort_values(by="sortkey", inplace=True)
 
-                names.append(plate_vol_comps["names"])
+                names.append(list(plate_vol_comps["names"]))
                 ea_vols.append((vol))
                 numbers.append((len(plate_vol_comps)))
                 tot_vols.append((vol * len(plate_vol_comps)))
                 source_concs.append((plate_vol_comps["source_concs"].iloc[0]))
                 dest_concs.append((plate_vol_comps["dest_concs"].iloc[0]))
                 plates.append(plate)
-                wells_list.append(plate_vol_comps["well"])
+                wells_list.append(list(plate_vol_comps["well"]))
 
         return [
             MixLine(
@@ -1502,7 +1506,7 @@ class MultiFixedConcentration(AbstractAction):
                 each_tx_vol=each_tx_vol,
                 total_tx_vol=total_tx_vol,
                 plate=p,
-                wells=wells
+                wells=wells,
             )
             for name, source_conc, dest_conc, number, each_tx_vol, total_tx_vol, p, wells in zip(
                 names,
@@ -1549,7 +1553,7 @@ class FixedRatio(AbstractAction):
                 str(self.dest_value) + "x",
                 self.tx_volume(mix_vol),
                 plate=self.component.plate,
-                wells=self.component._well_list
+                wells=self.component._well_list,
             )
         ]
 
@@ -1685,7 +1689,9 @@ class Mix(AbstractComponent):
     def validate(self, mixlines: Sequence[MixLine] | None = None) -> None:
         if mixlines is None:
             mixlines = self.mixlines()
-        ntx = [(m.names, m.total_tx_vol) for m in mixlines if m.total_tx_vol is not None]
+        ntx = [
+            (m.names, m.total_tx_vol) for m in mixlines if m.total_tx_vol is not None
+        ]
 
         nan_vols = [", ".join(n) for n, x in ntx if math.isnan(x.m)]
         if nan_vols:
@@ -1785,7 +1791,9 @@ class Mix(AbstractComponent):
                         (seq := getattr(row["component"], "sequence", None)) is not None
                     ):
                         new_tile.sequence |= seq
-                    new_tile.stoic = float(_ratio(Q_(row["concentration_nM"], nM), base_conc))
+                    new_tile.stoic = float(
+                        _ratio(Q_(row["concentration_nM"], nM), base_conc)
+                    )
                     newts.tiles.add(new_tile)
                     break
                 except KeyError:

--- a/src/alhambra/mixes.py
+++ b/src/alhambra/mixes.py
@@ -278,7 +278,7 @@ class WellPos:
 @attrs.define(eq=True)
 class MixLine:
     """Class for handling a line of a (processed) mix recipe.
-    
+
     Each line should represent a single step, or series of similar steps (same volume per substep)
     in the mixing process.
 
@@ -295,7 +295,7 @@ class MixLine:
         The destination/target concentration; may not be provided (will be left blank), or be a descriptive string.
 
     total_tx_vol
-        The total volume added to the mix by the step.  If zero, the amount will still be included in tables.  
+        The total volume added to the mix by the step.  If zero, the amount will still be included in tables.
         If None, the amount will be blank.  If provided, and the line is not fake, the value must be correct
         and interpretable for calculations involving the mix.
 
@@ -312,7 +312,7 @@ class MixLine:
     wells
         A list of wells for the components in a plate.  If the components are not in a plate, this must be an
         empty list.  This *does not* parse strings; wells must be provided as WellPos instances.
-    
+
     note
         A note to add for the line
 
@@ -369,27 +369,29 @@ class MixLine:
     def toline(self, incea: bool) -> Sequence[str]:
         if incea:
             return [
-                   _formatter(self.names, italic=self.fake),
-                   _formatter(self.source_conc, italic=self.fake),
-                   _formatter(self.dest_conc, italic=self.fake),
-                   _formatter(self.number, italic=self.fake) if self.number != 1 else "",
-                   _formatter(self.each_tx_vol, italic=self.fake),
-                   _formatter(self.total_tx_vol, italic=self.fake),
-                   _formatter(self.location, italic=self.fake),
-                   _formatter(self.note, italic=self.fake),
+                _formatter(self.names, italic=self.fake),
+                _formatter(self.source_conc, italic=self.fake),
+                _formatter(self.dest_conc, italic=self.fake),
+                _formatter(self.number, italic=self.fake) if self.number != 1 else "",
+                _formatter(self.each_tx_vol, italic=self.fake),
+                _formatter(self.total_tx_vol, italic=self.fake),
+                _formatter(self.location, italic=self.fake),
+                _formatter(self.note, italic=self.fake),
             ]
         else:
             return [
-                   _formatter(self.names, italic=self.fake),
-                   _formatter(self.source_conc, italic=self.fake),
-                   _formatter(self.dest_conc, italic=self.fake),
-                   _formatter(self.total_tx_vol, italic=self.fake),
-                   _formatter(self.location, italic=self.fake),
-                   _formatter(self.note, italic=self.fake),
+                _formatter(self.names, italic=self.fake),
+                _formatter(self.source_conc, italic=self.fake),
+                _formatter(self.dest_conc, italic=self.fake),
+                _formatter(self.total_tx_vol, italic=self.fake),
+                _formatter(self.location, italic=self.fake),
+                _formatter(self.note, italic=self.fake),
             ]
 
 
-def _formatter(x: int | float | str | list[str] | Quantity[Decimal] | None, italic: bool=False) -> str:
+def _formatter(
+    x: int | float | str | list[str] | Quantity[Decimal] | None, italic: bool = False
+) -> str:
     match x:
         case int(y) | str(y):
             out = str(y)
@@ -406,8 +408,9 @@ def _formatter(x: int | float | str | list[str] | Quantity[Decimal] | None, ital
     if not out:
         return ""
     if italic:
-        return "*"+out+"*"
+        return "*" + out + "*"
     return out
+
 
 class AbstractComponent(ABC):
     """Abstract class for a component in a mix."""

--- a/tests/test_mixes.py
+++ b/tests/test_mixes.py
@@ -254,6 +254,7 @@ def test_multifixedconc_min_volume(reference: Reference):
 
     m.table()
 
+
 def test_non_plates():
     s1 = Strand("s1", "200 nM", plate="tube")
 
@@ -263,7 +264,9 @@ def test_non_plates():
 
     s4 = Strand("s4", "400 nM", plate="a different tube")
 
-    m = Mix([MultiFixedVolume([s1, s2, s3, s4], "1 uL", equal_conc="min_volume")], "test")
+    m = Mix(
+        [MultiFixedVolume([s1, s2, s3, s4], "1 uL", equal_conc="min_volume")], "test"
+    )
 
     m.table()
 

--- a/tests/test_mixes.py
+++ b/tests/test_mixes.py
@@ -232,9 +232,15 @@ def test_a_mix(reference: Reference):
         is not None
     )
 
-    # FIXME: more tests of output
+    ml = m.mixlines()
 
-    # FIXME: test of chained mix
+    assert sum(l.total_tx_vol for l in ml if not l.fake) == m.total_volume
+
+    for line in ml:
+        if line.fake:
+            continue
+        if line.each_tx_vol:
+            assert line.number * line.each_tx_vol == line.total_tx_vol
 
 
 def test_multifixedconc_min_volume(reference: Reference):


### PR DESCRIPTION
Formatting of multi-component mixlines was previously done by each
action providing strings.  This moves formatting to a location
property on the MixLine, and a list of names on the MixLine, which it
then formats.

This has the slight potential for the bold formatting to become
confused, but addressing it would likely be harder than justified for
the slight formatting irregularities in a currently unknown edge case.