### PR TITLE
#30 put value of test tube name in table's mixline if a mix is used in another mix

### DIFF
--- a/src/alhambra/mixes.py
+++ b/src/alhambra/mixes.py
@@ -498,6 +498,9 @@ class AbstractComponent(ABC):
     def with_reference(self: T, reference: Reference) -> T:  # pragma: no cover
         ...
 
+    def printed_name(self) -> str:
+        return self.name
+
 
 def _parse_conc_optional(v: str | pint.Quantity | None) -> pint.Quantity:
     match v:
@@ -889,6 +892,7 @@ def findloc_tuples(
     return (loc["Name"], loc["Plate"], well)
 
 
+
 @attrs.define()
 class FixedConcentration(AbstractAction):
     """A mix action adding one component, at a fixed destination concentration.
@@ -942,7 +946,7 @@ class FixedConcentration(AbstractAction):
     ) -> list[MixLine]:
         return [
             MixLine(
-                names=[self.component.name],
+                names=[self.component.printed_name()],
                 source_conc=self.component.concentration,
                 dest_conc=self.dest_concentration(mix_vol),
                 each_tx_vol=self.tx_volume(mix_vol),
@@ -1016,7 +1020,7 @@ class FixedVolume(AbstractAction):
 
         return [
             MixLine(
-                names=[self.component.name],
+                names=[self.component.printed_name()],
                 source_conc=self.component.concentration,
                 dest_conc=self.dest_concentration(mix_vol),
                 total_tx_vol=self.tx_volume(mix_vol),
@@ -1237,7 +1241,7 @@ class MultiFixedVolume(AbstractAction):
         if not self.compact_display:
             ml = [
                 MixLine(
-                    [comp.name],
+                    [comp.printed_name()],
                     comp.concentration,
                     dc,
                     ev,
@@ -1283,7 +1287,7 @@ class MultiFixedVolume(AbstractAction):
 
         locdf = pd.DataFrame(
             {
-                "names": [c.name for c in self.components],
+                "names": [c.printed_name() for c in self.components],
                 "source_concs": self.source_concentrations,
                 "dest_concs": self.dest_concentrations(mix_vol),
                 "ea_vols": self.each_volumes(mix_vol),
@@ -1506,7 +1510,7 @@ class MultiFixedConcentration(AbstractAction):
         if not self.compact_display:
             ml = [
                 MixLine(
-                    [comp.name],
+                    [comp.printed_name()],
                     comp.concentration,
                     dc,
                     ev,
@@ -1546,7 +1550,7 @@ class MultiFixedConcentration(AbstractAction):
 
         locdf = pd.DataFrame(
             {
-                "names": [c.name for c in self.components],
+                "names": [c.printed_name() for c in self.components],
                 "source_concs": self.source_concentrations,
                 "dest_concs": self.dest_concentrations(mix_vol),
                 "ea_vols": self.each_volumes(mix_vol),
@@ -1794,6 +1798,9 @@ class Mix(AbstractComponent):
                 f"Mix.actions must contain at least one action, but it is empty"
             )
 
+    def printed_name(self) -> str:
+        return self.name + ("" if self.test_tube_name is None else f" (*{self.test_tube_name}*)")
+
     @property
     def concentration(self) -> Quantity[Decimal]:
         """
@@ -1948,12 +1955,14 @@ class Mix(AbstractComponent):
                 + "."
             )
 
-        # ensure
-        low_vols = [(n, x) for n, x in ntx if x < self.min_volume]
-        if len(low_vols) > 0:
-            raise VolumeError(
-                f"Some items have lower transfer volume than min_volume = {self.min_volume}"
-            )
+        # ensure we pipette at least self.min_volume from each source
+        for mixline in mixlines:
+            if mixline.each_tx_vol is not None and mixline.each_tx_vol < self.min_volume:
+                msg = f"Some items have lower transfer volume than min_volume = {self.min_volume}\n" \
+                      f'This is in creating mix "{self.name}", ' \
+                      f'attempting to pipette {mixline.each_tx_vol} of these components:\n' \
+                      f'{mixline.names}'
+                raise VolumeError(msg)
 
         # We'll check the last tx_vol first, because it is usually buffer.
         if ntx[-1][1] < ZERO_VOL:

--- a/src/alhambra/mixes.py
+++ b/src/alhambra/mixes.py
@@ -1435,7 +1435,9 @@ class MultiFixedConcentration(AbstractAction):
     set_name: str | None = None
     compact_display: bool = True
     min_volume: Quantity[Decimal] = attrs.field(
-        converter=_parse_vol_optional, default=Q_(DNAN, uL), on_setattr=attrs.setters.convert
+        converter=_parse_vol_optional,
+        default=Q_(DNAN, uL),
+        on_setattr=attrs.setters.convert,
     )
 
     def with_reference(self, reference: Reference) -> MultiFixedConcentration:

--- a/src/alhambra/mixes.py
+++ b/src/alhambra/mixes.py
@@ -892,7 +892,6 @@ def findloc_tuples(
     return (loc["Name"], loc["Plate"], well)
 
 
-
 @attrs.define()
 class FixedConcentration(AbstractAction):
     """A mix action adding one component, at a fixed destination concentration.
@@ -1799,7 +1798,9 @@ class Mix(AbstractComponent):
             )
 
     def printed_name(self) -> str:
-        return self.name + ("" if self.test_tube_name is None else f" (*{self.test_tube_name}*)")
+        return self.name + (
+            "" if self.test_tube_name is None else f" (*{self.test_tube_name}*)"
+        )
 
     @property
     def concentration(self) -> Quantity[Decimal]:
@@ -1957,11 +1958,16 @@ class Mix(AbstractComponent):
 
         # ensure we pipette at least self.min_volume from each source
         for mixline in mixlines:
-            if mixline.each_tx_vol is not None and mixline.each_tx_vol < self.min_volume:
-                msg = f"Some items have lower transfer volume than min_volume = {self.min_volume}\n" \
-                      f'This is in creating mix "{self.name}", ' \
-                      f'attempting to pipette {mixline.each_tx_vol} of these components:\n' \
-                      f'{mixline.names}'
+            if (
+                mixline.each_tx_vol is not None
+                and mixline.each_tx_vol < self.min_volume
+            ):
+                msg = (
+                    f"Some items have lower transfer volume than min_volume = {self.min_volume}\n"
+                    f'This is in creating mix "{self.name}", '
+                    f"attempting to pipette {mixline.each_tx_vol} of these components:\n"
+                    f"{mixline.names}"
+                )
                 raise VolumeError(msg)
 
         # We'll check the last tx_vol first, because it is usually buffer.

--- a/tests/test_mixes.py
+++ b/tests/test_mixes.py
@@ -270,7 +270,7 @@ def test_mix_min_volume(reference: Reference):
         [FixedConcentration(s1, "10 nM")],
         name="test",
         fixed_total_volume="100 uL",
-        min_volume = "20 uL",
+        min_volume="20 uL",
     )
 
     with pytest.raises(VolumeError):
@@ -293,8 +293,9 @@ def test_non_plates():
     s4 = Strand("s4", "400 nM", plate="a different tube")
 
     m = Mix(
-        [MultiFixedVolume([s1, s2, s3, s4], "1 uL", equal_conc="min_volume")], "test",
-        min_volume='0 uL',
+        [MultiFixedVolume([s1, s2, s3, s4], "1 uL", equal_conc="min_volume")],
+        "test",
+        min_volume="0 uL",
     )
 
     m.table()
@@ -352,7 +353,7 @@ def test_combine_plate_actions():
         ],
         name="test",
         fixed_total_volume="40uL",
-        min_volume='0 uL',
+        min_volume="0 uL",
     )
 
     combine_plate_actions = True
@@ -386,7 +387,7 @@ def test_combine_plate_actions_false():
         ],
         name="test",
         fixed_total_volume="40uL",
-        min_volume='0 uL',
+        min_volume="0 uL",
     )
 
     combine_plate_actions = False

--- a/tests/test_mixes.py
+++ b/tests/test_mixes.py
@@ -261,6 +261,28 @@ def test_multifixedconc_min_volume(reference: Reference):
     m.table()
 
 
+def test_mix_min_volume(reference: Reference):
+    s1 = Strand("strand1", "100 nM")
+
+    # should need 10 uL in 100 uL total volume to dilute from 100 nM to 10 nM,
+    # so set min_volume to 20 uL to trigger error
+    m = Mix(
+        [FixedConcentration(s1, "10 nM")],
+        name="test",
+        fixed_total_volume="100 uL",
+        min_volume = "20 uL",
+    )
+
+    with pytest.raises(VolumeError):
+        m.table()
+
+    # should need 20 uL in 200 uL total volume to dilute from 100 nM to 10 nM,
+    # so should work with min_volume=20 uL
+    m.fixed_total_volume = "200 uL"  # type: ignore  # Mypy doesn't understand on_setattr
+
+    m.table()
+
+
 def test_non_plates():
     s1 = Strand("s1", "200 nM", plate="tube")
 
@@ -271,7 +293,8 @@ def test_non_plates():
     s4 = Strand("s4", "400 nM", plate="a different tube")
 
     m = Mix(
-        [MultiFixedVolume([s1, s2, s3, s4], "1 uL", equal_conc="min_volume")], "test"
+        [MultiFixedVolume([s1, s2, s3, s4], "1 uL", equal_conc="min_volume")], "test",
+        min_volume='0 uL',
     )
 
     m.table()
@@ -329,6 +352,7 @@ def test_combine_plate_actions():
         ],
         name="test",
         fixed_total_volume="40uL",
+        min_volume='0 uL',
     )
 
     combine_plate_actions = True
@@ -362,6 +386,7 @@ def test_combine_plate_actions_false():
         ],
         name="test",
         fixed_total_volume="40uL",
+        min_volume='0 uL',
     )
 
     combine_plate_actions = False


### PR DESCRIPTION
Closes #30.

Merge this after #29; it's based off of that branch.

Also I snuck some bug fixes for #29 in here.