### PR TITLE
#43 cell borders on tables returned by `Mix.table()` and `PlateMap.to_table()`

### DIFF
--- a/src/alhambra/mixes.py
+++ b/src/alhambra/mixes.py
@@ -2593,7 +2593,11 @@ _ALL_TABLEFMTS = [
 
 # cast is to shut mypy up; should always be a str if not == html_with_borders_tablefmt
 _ALL_TABLEFMTS_NAMES: list[str] = [
-    (cast(str, fmt) if fmt != html_with_borders_tablefmt else "html_with_borders_tablefmt")
+    (
+        cast(str, fmt)
+        if fmt != html_with_borders_tablefmt
+        else "html_with_borders_tablefmt"
+    )
     for fmt in _ALL_TABLEFMTS
 ]
 

--- a/src/alhambra/mixes.py
+++ b/src/alhambra/mixes.py
@@ -2512,40 +2512,49 @@ class Mix(AbstractComponent):
             return existing_plate_map
 
 
-
-cell_with_border_css_class = 'cell-with-border'
+cell_with_border_css_class = "cell-with-border"
 
 # https://bitbucket.org/astanin/python-tabulate/issues/57/html-class-options-for-tables
-def _html_row_with_attrs(celltag: str, cell_values: Sequence[str],
-                         colwidths: Sequence[int], colaligns: Sequence[str]) -> str:
-    alignment = { "left":    '',
-                  "right":   ' style="text-align: right;"',
-                  "center":  ' style="text-align: center;"',
-                  "decimal": ' style="text-align: right;"' }
-    values_with_attrs =\
-        [f"<{celltag}{alignment.get(a, '')} class=\"{cell_with_border_css_class}\">{c}</{celltag}>"
-         for c, a in zip(cell_values, colaligns)]
-    return "<tr>" + \
-            "".join(values_with_attrs).rstrip() + \
-            "</tr>"
+def _html_row_with_attrs(
+    celltag: str,
+    cell_values: Sequence[str],
+    colwidths: Sequence[int],
+    colaligns: Sequence[str],
+) -> str:
+    alignment = {
+        "left": "",
+        "right": ' style="text-align: right;"',
+        "center": ' style="text-align: center;"',
+        "decimal": ' style="text-align: right;"',
+    }
+    values_with_attrs = [
+        f"<{celltag}{alignment.get(a, '')} class=\"{cell_with_border_css_class}\">{c}</{celltag}>"
+        for c, a in zip(cell_values, colaligns)
+    ]
+    return "<tr>" + "".join(values_with_attrs).rstrip() + "</tr>"
 
 
 from functools import partial
 
 html_with_borders_tablefmt = TableFormat(
-    lineabove=Line(f"""\
+    lineabove=Line(
+        f"""\
 <style>
 th.{cell_with_border_css_class}, td.{cell_with_border_css_class} {{ 
     border: 1px solid black; 
 }}
 </style>
 <table>\
-""", "", "", ""),
+""",
+        "",
+        "",
+        "",
+    ),
     linebelowheader=None,
     linebetweenrows=None,
     linebelow=Line("</table>", "", "", ""),
-    headerrow=partial(_html_row_with_attrs, "th"), # type: ignore
-    datarow=partial(_html_row_with_attrs, "td"), # type: ignore
+    headerrow=partial(_html_row_with_attrs, "th"),  # type: ignore
+    datarow=partial(_html_row_with_attrs, "td"),  # type: ignore
     padding=0,
     with_header_hide=None,
 )

--- a/src/alhambra/mixes.py
+++ b/src/alhambra/mixes.py
@@ -2591,8 +2591,9 @@ _ALL_TABLEFMTS = [
     html_with_borders_tablefmt,
 ]
 
-_ALL_TABLEFMTS_NAMES = [
-    (fmt if fmt != html_with_borders_tablefmt else "html_with_borders_tablefmt")
+# cast is to shut mypy up; should always be a str if not == html_with_borders_tablefmt
+_ALL_TABLEFMTS_NAMES: list[str] = [
+    (cast(str, fmt) if fmt != html_with_borders_tablefmt else "html_with_borders_tablefmt")
     for fmt in _ALL_TABLEFMTS
 ]
 

--- a/src/alhambra/mixes.py
+++ b/src/alhambra/mixes.py
@@ -2590,6 +2590,11 @@ _ALL_TABLEFMTS = [
     html_with_borders_tablefmt,
 ]
 
+_ALL_TABLEFMTS_NAMES = [
+    (fmt if fmt != html_with_borders_tablefmt else "html_with_borders_tablefmt")
+    for fmt in _ALL_TABLEFMTS
+]
+
 _SUPPORTED_TABLEFMTS_TITLE = [
     "github",
     "pipe",
@@ -2710,7 +2715,7 @@ class PlateMap:
         if tablefmt not in _ALL_TABLEFMTS:
             raise ValueError(
                 f"tablefmt {tablefmt} not recognized; "
-                f'choose one of {", ".join(_ALL_TABLEFMTS)}'
+                f'choose one of {", ".join(_ALL_TABLEFMTS_NAMES)}'
             )
         elif (
             tablefmt not in _SUPPORTED_TABLEFMTS_TITLE and warn_unsupported_title_format

--- a/src/alhambra/mixes.py
+++ b/src/alhambra/mixes.py
@@ -38,7 +38,7 @@ from pathlib import Path
 import numpy as np
 import pandas as pd
 import pint
-from tabulate import tabulate, TableFormat
+from tabulate import tabulate, TableFormat, Line
 
 from alhambra.seeds import Seed
 
@@ -2512,6 +2512,48 @@ class Mix(AbstractComponent):
             return existing_plate_map
 
 
+
+cell_with_border_css_class = 'cell-with-border'
+
+# https://bitbucket.org/astanin/python-tabulate/issues/57/html-class-options-for-tables
+def _html_row_with_attrs(celltag: str, cell_values: Sequence[str],
+                         colwidths: Sequence[int], colaligns: Sequence[str]) -> str:
+    alignment = { "left":    '',
+                  "right":   ' style="text-align: right;"',
+                  "center":  ' style="text-align: center;"',
+                  "decimal": ' style="text-align: right;"' }
+    values_with_attrs =\
+        [f"<{celltag}{alignment.get(a, '')} class=\"{cell_with_border_css_class}\">{c}</{celltag}>"
+         for c, a in zip(cell_values, colaligns)]
+    return "<tr>" + \
+            "".join(values_with_attrs).rstrip() + \
+            "</tr>"
+
+
+from functools import partial
+
+html_with_borders_tablefmt = TableFormat(
+    lineabove=Line(f"""\
+<style>
+th.{cell_with_border_css_class}, td.{cell_with_border_css_class} {{ 
+    border: 1px solid black; 
+}}
+</style>
+<table>\
+""", "", "", ""),
+    linebelowheader=None,
+    linebetweenrows=None,
+    linebelow=Line("</table>", "", "", ""),
+    headerrow=partial(_html_row_with_attrs, "th"), # type: ignore
+    datarow=partial(_html_row_with_attrs, "td"), # type: ignore
+    padding=0,
+    with_header_hide=None,
+)
+"""
+Pass this as the parameter `tablefmt` in any method that accepts that parameter to have the table
+be an HTML table with borders around each cell.
+"""
+
 _ALL_TABLEFMTS = [
     "plain",
     "simple",
@@ -2536,6 +2578,7 @@ _ALL_TABLEFMTS = [
     "latex_longtable",
     "textile",
     "tsv",
+    html_with_borders_tablefmt,
 ]
 
 _SUPPORTED_TABLEFMTS_TITLE = [
@@ -2550,6 +2593,7 @@ _SUPPORTED_TABLEFMTS_TITLE = [
     "latex_raw",
     "latex_booktabs",
     "latex_longtable",
+    html_with_borders_tablefmt,
 ]
 
 
@@ -2718,7 +2762,7 @@ def _format_title(
 ) -> str:
     # formats a title for a table produced using tabulate,
     # in the formats tabulate understands
-    if tablefmt in ["html", "unsafehtml"]:
+    if tablefmt in ["html", "unsafehtml", html_with_borders_tablefmt]:
         title = f"<h{level}>{raw_title}</h{level}>"
     elif tablefmt == "rst":
         # https://draft-edx-style-guide.readthedocs.io/en/latest/ExampleRSTFile.html#heading-levels


### PR DESCRIPTION
See #43.

I based this branch off of #38, so once PR #42 is merged, the file diffs should be easier to check.