### PR TITLE
#45 use html emphasis in mix table when `tablefmt` is an html variant

### DIFF
--- a/src/alhambra/mixes.py
+++ b/src/alhambra/mixes.py
@@ -2838,8 +2838,9 @@ class PlateMap:
                 if not well_pos.is_last():
                     well_pos = well_pos.advance()
 
+        from alhambra.quantitate import normalize
         raw_title = f'plate "{self.plate_name}"' + (
-            f", {self.vol_each} each" if self.vol_each is not None else ""
+            f", {normalize(self.vol_each)} each" if self.vol_each is not None else ""
         )
         title = _format_title(raw_title, title_level, tablefmt)
 

--- a/tests/test_mixes.py
+++ b/tests/test_mixes.py
@@ -232,7 +232,7 @@ def test_a_mix(reference: Reference):
         is not None
     )
 
-    ml = m.mixlines()
+    ml = m.mixlines(tablefmt='pipe')
 
     assert sum(l.total_tx_vol for l in ml if not l.fake) == m.total_volume
 
@@ -300,7 +300,7 @@ def test_non_plates():
 
     m.table()
 
-    ml = m.mixlines()
+    ml = m.mixlines(tablefmt='pipe')
 
     assert len(ml) == 4
 


### PR DESCRIPTION
See issue #45. Based this branch off of https://github.com/DNA-and-Natural-Algorithms-Group/alhambra/tree/%2343-inline-styles-on-tables-returned-by-Mix.table()-and-PlateMap.to_table(), so diff with branch v2 will be simpler once PR #44 is merged.